### PR TITLE
let user set event source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [0.0.5] - 2016-06-02
+### Changed
+- let the user set their event source
+
 ## [0.0.4] - 2015-07-14
 ### Changed
 - updated sensu-plugin gem to 1.2.0
@@ -16,7 +20,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Changed
 - removed cruft from /lib
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-datadog/compare/0.0.4...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-datadog/compare/0.0.5...HEAD
+[0.0.5]: https://github.com/sensu-plugins/sensu-plugins-datadog/compare/0.0.4...0.0.5
 [0.0.4]: https://github.com/sensu-plugins/sensu-plugins-datadog/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/sensu-plugins/sensu-plugins-datadog/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/sensu-plugins/sensu-plugins-datadog/compare/0.0.1...0.0.2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ```json
 {
   "datadog": {
+    "source_type_name": "nagios",
     "api_key": "12345",
     "app_key": "54321",
     "tags": []

--- a/bin/datadog-notification.rb
+++ b/bin/datadog-notification.rb
@@ -88,7 +88,7 @@ class DatadogNotif < Sensu::Handler
                                     tags: tags,
                                     alert_type: action,
                                     priority: priority,
-                                    source_type_name: 'nagios', # make events appear as nagios alerts so the weekly nagios report can be produced
+                                    source_type_name: settings['datadog']['source_type_name'] || 'sensu', # let the user set the source_type_name
                                     aggregation_key: @event['check']['name']
         ), host: @event['client']['name'])
 

--- a/lib/sensu-plugins-datadog/version.rb
+++ b/lib/sensu-plugins-datadog/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsDatadog
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 4
+    PATCH = 5
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### New Plugins

I didn't add a new plugin.
#### Purpose

Not everyone uses nagios, and it would be nice if the user could set their event source name in the settings.
#### Known Compatablity Issues

Users that were relying on `nagios` being hard-coded as the event source in [datadog-notification.rb](https://github.com/sensu-plugins/sensu-plugins-datadog/blob/master/bin/datadog-notification.rb#L91) will now need to update their settings.
